### PR TITLE
Integrate Applixir video ads

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import EarningsCard from "@/components/EarningsCard";
-import React from "react";
+import VideoAd from "@/components/VideoAd";
+import React, { useState } from "react";
 import {
   SafeAreaView,
   View,
@@ -13,6 +14,7 @@ import {
 import { earnings } from "../constants/mockData";
 
 export default function HomeScreen() {
+  const [adVisible, setAdVisible] = useState(false);
   return (
     <SafeAreaView style={styles.safeContainer}>
       <ScrollView style={styles.scrollContainer}>
@@ -60,7 +62,7 @@ export default function HomeScreen() {
             </View>
           </View>
 
-          <View style={styles.bonusRow}>
+          <TouchableOpacity style={styles.bonusRow} onPress={() => setAdVisible(true)}>
             <Image
               source={{ uri: "https://storage.googleapis.com/tagjs-prod.appspot.com/v1/SbVinpZIfd/fr22k70p_expires_30_days.png" }}
               style={styles.bonusImageLeft}
@@ -77,7 +79,7 @@ export default function HomeScreen() {
               style={styles.bonusImageRight}
               resizeMode="stretch"
             />
-          </View>
+          </TouchableOpacity>
         </View>
 
         {/* Survey Section */}
@@ -106,6 +108,7 @@ export default function HomeScreen() {
         ))}
       </ScrollView>
       </ScrollView>
+      <VideoAd visible={adVisible} onClose={() => setAdVisible(false)} />
     </SafeAreaView>
   );
 }

--- a/components/VideoAd.tsx
+++ b/components/VideoAd.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect } from "react";
+import { Platform, View, Button } from "react-native";
+import { WebView } from "react-native-webview";
+
+const API_KEY = "55c09aea-7355-4266-8454-edee59ed4c4f";
+const INJECTION_ID = "some-id";
+
+export default function VideoAd() {
+  // Web implementation: inject the Applixir script and open player on button press
+  if (Platform.OS === "web") {
+    useEffect(() => {
+      if (!document.getElementById("applixir-script")) {
+        const script = document.createElement("script");
+        script.id = "applixir-script";
+        script.src = "https://cdn.applixir.com/applixir.app.v6.0.1.js";
+        script.async = true;
+        document.body.appendChild(script);
+      }
+    }, []);
+
+    const handlePress = () => {
+      const options = {
+        apiKey: API_KEY,
+        injectionElementId: INJECTION_ID,
+        adStatusCallbackFn: (status: any) => console.log("OUTSIDE Ad status: ", status),
+        adErrorCallbackFn: (error: any) => console.log("Error: ", error.getError().data),
+      };
+      // @ts-ignore
+      if (typeof initializeAndOpenPlayer === "function") {
+        // @ts-ignore
+        initializeAndOpenPlayer(options);
+      }
+    };
+
+    return (
+      <View>
+        <div id={INJECTION_ID}></div>
+        <Button title="Play Ad" onPress={handlePress} />
+      </View>
+    );
+  }
+
+  // Native implementation: use a WebView with embedded HTML
+  const html = `
+    <div id="${INJECTION_ID}"></div>
+    <button id="start">Play Ad</button>
+    <script type="text/javascript" src="https://cdn.applixir.com/applixir.app.v6.0.1.js"></script>
+    <script type="text/javascript">
+      const options = {
+        apiKey: "${API_KEY}",
+        injectionElementId: "${INJECTION_ID}",
+        adStatusCallbackFn: (status) => {
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'status', status }));
+        },
+        adErrorCallbackFn: (error) => {
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'error', error: error.getError().data }));
+        },
+      };
+      document.getElementById('start').addEventListener('click', () => {
+        initializeAndOpenPlayer(options);
+      });
+    </script>`;
+
+  return <WebView originWhitelist={["*"]} source={{ html }} />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-native-screens": "~4.11.1",
         "react-native-svg": "15.11.2",
         "react-native-web": "~0.20.0",
+        "react-native-webview": "^13.15.0",
         "three": "^0.166.1",
         "three-stdlib": "^2.36.0"
       },
@@ -10286,6 +10287,19 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
+      "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
       "version": "0.79.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-web": "~0.20.0",
+    "react-native-webview": "^13.15.0",
     "three": "^0.166.1",
     "three-stdlib": "^2.36.0"
   },


### PR DESCRIPTION
## Summary
- implement a VideoAd component that loads Applixir ads on web and native
- use production API key

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebc80eabc83309073aba36fb564a5