### PR TITLE
Implement new menu tabs

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,19 +2,13 @@ import React from 'react';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { Link, Tabs } from 'expo-router';
 import { Pressable } from 'react-native';
+import MenuTab from '@/components/MenuTab';
 
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
 import { useClientOnlyValue } from '@/components/useClientOnlyValue';
 
 // You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
-function TabBarIcon(props: {
-  name: React.ComponentProps<typeof FontAwesome>['name'];
-  color: string;
-}) {
-  return <FontAwesome size={28} style={{ marginBottom: -3 }} {...props} />;
-}
-
 export default function TabLayout() {
   const colorScheme = useColorScheme();
 
@@ -22,15 +16,17 @@ export default function TabLayout() {
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
-        // Disable the static render of the header on web
-        // to prevent a hydration error in React Navigation v6.
         headerShown: useClientOnlyValue(false, true),
-      }}>
+        tabBarShowLabel: false,
+      }}
+    >
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Tab One',
-          tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
+          title: 'Station',
+          tabBarIcon: ({ focused }) => (
+            <MenuTab label="STATION" focused={focused} />
+          ),
           headerRight: () => (
             <Link href="/modal" asChild>
               <Pressable>
@@ -51,7 +47,9 @@ export default function TabLayout() {
         name="two"
         options={{
           title: 'Tab Two',
-          tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
+          tabBarIcon: ({ focused }) => (
+            <MenuTab label="TAB TWO" focused={focused} />
+          ),
         }}
       />
     </Tabs>

--- a/components/MenuTab.tsx
+++ b/components/MenuTab.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Svg, Path } from 'react-native-svg';
+
+export type MenuTabProps = {
+  label: string;
+  focused?: boolean;
+};
+
+export default function MenuTab({ label, focused }: MenuTabProps) {
+  return (
+    <View
+      style={[
+        styles.menuTabContainer,
+        focused && styles.activeContainer,
+      ]}
+    >
+      <Svg
+        style={styles.group}
+        width={25}
+        height={24}
+        viewBox="0 0 25 24"
+        fill="none"
+      >
+        <Path d="M22 12.7995V21L15.7448 14.9548L15.0688 15.6051L13 17.6074L10.2552 14.9548L4 21V12.7995L8.7588 8.20345L10.001 7V9.40395L10.9281 10.3014L12.1551 11.4872L13 12.3037L13.8434 11.4872L15.0688 10.3029L15.999 9.40395V7L22 12.7995Z" fill="#A68763" />
+        <Path d="M15 2.50097L14.2673 3.23373V8.23308L12.5006 10L10.734 8.23308V3.23373L10 2.50097L10.734 1.76692L12.5006 0L14.2673 1.76692L15 2.50097Z" fill="#A68763" />
+        <Path d="M17 20.857V23.9954L13.0016 20.143L9 24V20.857L13.0016 17L14.6342 18.5715L17 20.857Z" fill="#A68763" />
+      </Svg>
+      <Text style={styles.label}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  menuTabContainer: {
+    position: 'relative',
+    flexShrink: 0,
+    borderTopWidth: 0,
+    borderRightWidth: 0,
+    borderBottomWidth: 2,
+    borderLeftWidth: 0,
+    borderStyle: 'solid',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    rowGap: 6,
+    padding: 10,
+    borderColor: 'transparent',
+  },
+  activeContainer: {
+    borderColor: 'rgba(255, 240, 169, 1)',
+  },
+  group: {
+    position: 'relative',
+    flexShrink: 0,
+    height: 24,
+    width: 24,
+  },
+  label: {
+    position: 'relative',
+    flexShrink: 0,
+    textAlign: 'center',
+    color: 'rgba(255, 255, 255, 1)',
+    fontFamily: 'Rajdhani',
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 14,
+  },
+});


### PR DESCRIPTION
## Summary
- add customizable `MenuTab` component for bottom tabs
- wire `MenuTab` into tab layout

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_68714e45b9fc8330b7a33d5f1587b9da