### PR TITLE
Implement dynamic streak rewards

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -27,6 +27,13 @@ export default function HomeScreen() {
   const [streakDrawerOpen, setStreakDrawerOpen] = useState(false);
   const [streak, setStreak] = useState(0);
   const [earningsVal, setEarningsVal] = useState(0);
+  const [extendedToday, setExtendedToday] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [achievements, setAchievements] = useState({
+    daily: 0,
+    weekly: 0,
+    monthly: 0,
+  });
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async (user) => {
@@ -52,12 +59,17 @@ export default function HomeScreen() {
     let unsubSnap: () => void = () => {};
     const unsubAuth = onAuthStateChanged(auth, async (user) => {
       if (user) {
-        const s = await updateUserStreak(user.uid);
-        setStreak(s);
+        const res = await updateUserStreak(user.uid);
+        setStreak(res.streak);
+        setExtendedToday(res.extendedToday);
+        setProgress(res.progress);
+        setAchievements(res.achievements);
         unsubSnap = onSnapshot(doc(db, 'users', user.uid), (snap) => {
           const data: any = snap.data();
           setEarningsVal(data?.earnings ?? 0);
-          setStreak(data?.streak ?? s);
+          setStreak(data?.streak ?? res.streak);
+          setProgress(data?.achievementProgress ?? res.progress);
+          setAchievements(data?.achievements ?? res.achievements);
         });
       }
     });
@@ -165,6 +177,9 @@ export default function HomeScreen() {
         visible={streakDrawerOpen}
         onClose={() => setStreakDrawerOpen(false)}
         streak={streak}
+        progress={progress}
+        extendedToday={extendedToday}
+        achievements={achievements}
       />
       <VideoAd visible={adVisible} onClose={() => setAdVisible(false)} />
     </SafeAreaView>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,12 +19,12 @@ export default function Header({ onPressStreak, earnings = 0, streak = 0 }: Head
     let unsubSnap: () => void = () => {};
     const unsubAuth = onAuthStateChanged(auth, async (user) => {
       if (user) {
-        const s = await updateUserStreak(user.uid);
-        setStreakVal(s);
+        const res = await updateUserStreak(user.uid);
+        setStreakVal(res.streak);
         unsubSnap = onSnapshot(doc(db, 'users', user.uid), (snap) => {
           const data: any = snap.data();
           setEarnVal(data?.earnings ?? 0);
-          setStreakVal(data?.streak ?? s);
+          setStreakVal(data?.streak ?? res.streak);
         });
       }
     });

--- a/components/StreakDrawer.tsx
+++ b/components/StreakDrawer.tsx
@@ -13,6 +13,13 @@ export type StreakDrawerProps = {
   visible: boolean;
   onClose: () => void;
   streak: number;
+  progress?: number;
+  extendedToday?: boolean;
+  achievements?: {
+    daily: number;
+    weekly: number;
+    monthly: number;
+  };
 };
 
 const weekDays = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
@@ -21,6 +28,9 @@ export default function StreakDrawer({
   visible,
   onClose,
   streak,
+  progress = 0,
+  extendedToday = false,
+  achievements = { daily: 0, weekly: 0, monthly: 0 },
 }: StreakDrawerProps) {
   const dayCircles = weekDays.map((d, i) => {
     const active = i < streak % 7;
@@ -35,6 +45,14 @@ export default function StreakDrawer({
       </View>
     );
   });
+
+  const progress3 = Math.min(progress, 3);
+  const progress10 = Math.min(progress, 10);
+  const progress30 = Math.min(progress, 30);
+
+  const pct3 = (progress3 / 3) * 100;
+  const pct10 = (progress10 / 10) * 100;
+  const pct30 = (progress30 / 30) * 100;
 
   return (
     <BottomDrawer isOpen={visible} onClose={onClose}>
@@ -64,11 +82,13 @@ export default function StreakDrawer({
         </View>
 
         <View style={styles.week}>{dayCircles}</View>
-        <View style={styles.infoBox}>
-          <Text style={styles.infoText}>
-            You've extended your streak today!
-          </Text>
-        </View>
+        {extendedToday && (
+          <View style={styles.infoBox}>
+            <Text style={styles.infoText}>
+              You've extended your streak today!
+            </Text>
+          </View>
+        )}
 
         <View style={{ marginTop: 24 }}>
           <View style={styles.achieveHeader}>
@@ -82,12 +102,12 @@ export default function StreakDrawer({
             />
             <View style={{ flex: 1 }}>
               <Text style={styles.achieveName}>Hat Trick</Text>
-              <Text style={styles.achieveSub}>3 day streak</Text>
+              <Text style={styles.achieveSub}>{progress3}/3 day streak</Text>
               <View style={styles.progressBar}>
-                <View style={[styles.progressInner, { width: "100%" }]} />
+                <View style={[styles.progressInner, { width: `${pct3}%` }]} />
               </View>
             </View>
-            <Text style={styles.earned}>5¢ earned</Text>
+            <Text style={styles.earned}>{`$${(achievements.daily * 0.01).toFixed(2)} daily`}</Text>
           </View>
           <View style={styles.achievementRow}>
             <Image
@@ -96,13 +116,13 @@ export default function StreakDrawer({
             />
             <View style={{ flex: 1 }}>
               <Text style={styles.achieveName}>007</Text>
-              <Text style={styles.achieveSub}>3/7 day streak</Text>
+              <Text style={styles.achieveSub}>{progress10}/10 day streak</Text>
               <View style={styles.progressBar}>
-                <View style={[styles.progressInner, { width: "42%" }]} />
+                <View style={[styles.progressInner, { width: `${pct10}%` }]} />
               </View>
             </View>
             <View style={styles.reward}>
-              <Text style={styles.rewardText}>10¢</Text>
+              <Text style={styles.rewardText}>{`$${(achievements.weekly * 0.05).toFixed(2)} weekly`}</Text>
             </View>
           </View>
           <View style={styles.achievementRow}>
@@ -112,13 +132,13 @@ export default function StreakDrawer({
             />
             <View style={{ flex: 1 }}>
               <Text style={styles.achieveName}>Dirty Thirty</Text>
-              <Text style={styles.achieveSub}>3/30 day streak</Text>
+              <Text style={styles.achieveSub}>{progress30}/30 day streak</Text>
               <View style={styles.progressBar}>
-                <View style={[styles.progressInner, { width: "10%" }]} />
+                <View style={[styles.progressInner, { width: `${pct30}%` }]} />
               </View>
             </View>
             <View style={styles.reward}>
-              <Text style={styles.rewardText}>75¢</Text>
+              <Text style={styles.rewardText}>{`$${(achievements.monthly * 0.25).toFixed(2)} monthly`}</Text>
             </View>
           </View>
         </View>

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -1,7 +1,22 @@
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db } from './firebase';
 
-export async function updateUserStreak(userId: string): Promise<number> {
+export type StreakInfo = {
+  streak: number;
+  extendedToday: boolean;
+  progress: number;
+  achievements: {
+    daily: number;
+    weekly: number;
+    monthly: number;
+  };
+};
+
+function sameDay(a: Date, b: Date) {
+  return a.toDateString() === b.toDateString();
+}
+
+export async function updateUserStreak(userId: string): Promise<StreakInfo> {
   const ref = doc(db, 'users', userId);
   const snap = await getDoc(ref);
   const data: any = snap.data() || {};
@@ -12,20 +27,107 @@ export async function updateUserStreak(userId: string): Promise<number> {
     ? new Date(data.lastActivity)
     : undefined;
   const today = new Date();
-  const todayStr = today.toDateString();
   let streak = data.streak || 0;
+  let progress = data.achievementProgress || 0;
+  const achievements = data.achievements || { daily: 0, weekly: 0, monthly: 0 };
+  let extendedToday = false;
 
-  if (last && new Date(last).toDateString() === todayStr) {
-    // already counted today
-  } else {
+  const earnings = data.earnings || 0;
+  const lastEarnTotal = data.lastEarnTotal || 0;
+  const earnedDiff = parseFloat((earnings - lastEarnTotal).toFixed(2));
+
+  if (!last || !sameDay(last, today)) {
     const yesterday = new Date(today);
     yesterday.setDate(today.getDate() - 1);
-    if (last && new Date(last).toDateString() === yesterday.toDateString()) {
-      streak += 1;
-    } else {
-      streak = 1;
+    if (earnedDiff >= 0.01) {
+      if (last && sameDay(last, yesterday)) {
+        streak += 1;
+      } else {
+        streak = 1;
+      }
+      progress += 1;
+      extendedToday = true;
+
+      if (progress === 3) {
+        achievements.daily = (achievements.daily || 0) + 1;
+      } else if (progress === 10) {
+        achievements.weekly = (achievements.weekly || 0) + 1;
+      } else if (progress === 30) {
+        achievements.monthly = (achievements.monthly || 0) + 1;
+        progress = 0;
+      }
+
+      await setDoc(
+        ref,
+        {
+          streak,
+          lastActivity: today,
+          lastEarnTotal: earnings,
+          achievementProgress: progress,
+          achievements,
+        },
+        { merge: true }
+      );
+    } else if (!last || !sameDay(last, yesterday)) {
+      // missed a day without earning
+      streak = 0;
+      await setDoc(ref, { streak }, { merge: true });
     }
-    await setDoc(ref, { streak, lastActivity: today }, { merge: true });
   }
-  return streak;
+
+  // apply recurring bonuses without affecting streak
+  let updated = false;
+  const updates: any = {};
+  let total = earnings;
+
+  if (achievements.daily > 0) {
+    const lastDaily: Date | undefined = data.lastDailyBonus?.toDate
+      ? data.lastDailyBonus.toDate()
+      : data.lastDailyBonus
+      ? new Date(data.lastDailyBonus)
+      : undefined;
+    if (!lastDaily || !sameDay(lastDaily, today)) {
+      total += achievements.daily * 0.01;
+      updates.lastDailyBonus = today;
+      updated = true;
+    }
+  }
+
+  if (achievements.weekly > 0) {
+    const lastWeekly: Date | undefined = data.lastWeeklyBonus?.toDate
+      ? data.lastWeeklyBonus.toDate()
+      : data.lastWeeklyBonus
+      ? new Date(data.lastWeeklyBonus)
+      : undefined;
+    if (!lastWeekly || today.getTime() - lastWeekly.getTime() >= 7 * 864e5) {
+      total += achievements.weekly * 0.05;
+      updates.lastWeeklyBonus = today;
+      updated = true;
+    }
+  }
+
+  if (achievements.monthly > 0) {
+    const lastMonthly: Date | undefined = data.lastMonthlyBonus?.toDate
+      ? data.lastMonthlyBonus.toDate()
+      : data.lastMonthlyBonus
+      ? new Date(data.lastMonthlyBonus)
+      : undefined;
+    if (
+      !lastMonthly ||
+      lastMonthly.getFullYear() !== today.getFullYear() ||
+      lastMonthly.getMonth() !== today.getMonth()
+    ) {
+      total += achievements.monthly * 0.25;
+      updates.lastMonthlyBonus = today;
+      updated = true;
+    }
+  }
+
+  if (updated) {
+    updates.earnings = parseFloat(total.toFixed(2));
+    updates.lastEarnTotal = parseFloat(total.toFixed(2));
+    await setDoc(ref, updates, { merge: true });
+  }
+
+  return { streak, extendedToday, progress, achievements };
 }


### PR DESCRIPTION
## Summary
- revise streak logic to track earnings-based activity
- add automatic bonus rewards for streak achievements
- show streak progress and achievements in the Streak drawer
- surface extended streak info in header and home screen

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878d767f2908330a9b875a0e54246aa