### PR TITLE
Fix iOS crash and avatar url

### DIFF
--- a/lib/ReadyPlayerMe.ts
+++ b/lib/ReadyPlayerMe.ts
@@ -85,11 +85,10 @@ export default class ReadyPlayerMe {
   }
 
   static async getAvatarGLBUrl(avatarId: string, preview = false): Promise<string> {
-    if (preview) {
-      return `${API_BASE_V2}/avatars/${avatarId}.glb?preview=true`;
-    } else {
-      return `${MODEL_BASE}/${avatarId}.glb`;
-    }
+    const base = MODEL_BASE;
+    return preview
+      ? `${base}/${avatarId}.glb?preview=true`
+      : `${base}/${avatarId}.glb`;
   }
 
   static async getAssets(
@@ -127,3 +126,4 @@ export default class ReadyPlayerMe {
     return json.data;
   }
 }
+

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,5 +1,4 @@
 import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
@@ -7,7 +6,7 @@ const firebaseConfig = {
   apiKey: "AIzaSyDvtmin3K9r_cZNk5EFkVbqqBPVk55YQNE",
   authDomain: "arcadia-a6127.firebaseapp.com",
   projectId: "arcadia-a6127",
-  storageBucket: "arcadia-a6127.firebasestorage.app",
+  storageBucket: "arcadia-a6127.appspot.com",
   messagingSenderId: "1083551279704",
   appId: "1:1083551279704:web:67ec81650a282094bdf82d",
   measurementId: "G-2VTJ3L330L",
@@ -16,4 +15,4 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
-export const analytics = getAnalytics(app);
+


### PR DESCRIPTION
## Summary
- remove unsupported firebase analytics usage
- correct Firebase storage bucket
- always load Ready Player Me avatars from models.readyplayer.me

## Testing
- `npm install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687ac77ee99c8330b9a16cb2105371b0